### PR TITLE
Add FIBO to Neo4j conversion tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # LeadershipCounselor
 An Chatbot who helps you be more concise and drive better communication in your space
+
+## FIBO → Neo4j loader
+
+This repository now includes a reusable Python tool for converting the
+[EDM Council FIBO ontology](https://github.com/edmcouncil/fibo) into a Neo4j
+semantic graph. The tool parses the Turtle/RDF/OWL files in a local checkout of
+the FIBO repository, extracts ontology concepts, properties, individuals and
+relationships, and then either:
+
+1. Loads the content directly into a running Neo4j instance using the official
+   [`neo4j` Python driver](https://pypi.org/project/neo4j/), or
+2. Exports CSV files (`nodes.csv` and `relationships.csv`) that are ready for
+   Neo4j bulk import workflows.
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Usage
+
+1. Clone or download the `edmcouncil/fibo` repository (or unpack a release
+   archive) locally.
+2. Run the CLI with the path to the FIBO sources:
+
+```bash
+python -m fibo_neo4j.cli /path/to/fibo \
+  --neo4j-uri bolt://localhost:7687 \
+  --neo4j-user neo4j
+```
+
+You will be prompted for the Neo4j password if it is not supplied via the
+`--neo4j-password` flag. To generate CSV output instead (or in addition), use
+`--output-dir`:
+
+```bash
+python -m fibo_neo4j.cli /path/to/fibo --output-dir ./neo4j-export
+```
+
+Additional options:
+
+- `--limit-files N` – parse only the first `N` ontology files (handy for
+  smoke-testing the pipeline).
+- `--batch-size N` – control the batch size used when writing to Neo4j.
+- `--dry-run` – parse and report counts without touching Neo4j.
+- `--no-constraints` – skip creation of the Neo4j uniqueness constraint on
+  `Resource.uri`.
+
+The loader captures structural relationships such as subclass hierarchies,
+property domains/ranges, equivalence links, SKOS links, imports and more. Each
+node stores labels, definitions, comments and provenance (source file list) to
+aid downstream conversational AI workflows that rely on ontology-driven intent
+clarification.

--- a/fibo_neo4j/__init__.py
+++ b/fibo_neo4j/__init__.py
@@ -1,0 +1,7 @@
+"""Utilities for converting FIBO ontologies into Neo4j graphs."""
+
+__all__ = [
+    "build_graph",
+]
+
+from .builder import build_graph  # noqa: E402  (import after definition for __all__)

--- a/fibo_neo4j/builder.py
+++ b/fibo_neo4j/builder.py
@@ -1,0 +1,374 @@
+"""Build a Neo4j-ready representation of the FIBO ontology."""
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+import rdflib
+from rdflib import Literal, URIRef
+from rdflib.namespace import DCTERMS, OWL, RDF, RDFS, SKOS, XSD
+from rdflib.util import guess_format
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _format_literal(value: Literal) -> str:
+    """Render a literal value with language/datatype hints."""
+    text = str(value)
+    if value.language:
+        return f"{text} (@{value.language})"
+    if value.datatype and value.datatype != XSD.string:
+        return f"{text}^^{value.datatype}"  # include datatype when it is not xsd:string
+    return text
+
+
+def _split_namespace(uri: str) -> Tuple[Optional[str], Optional[str]]:
+    """Split a URI into namespace/local name, best effort."""
+    try:
+        namespace, local = rdflib.namespace.split_uri(URIRef(uri))
+        return namespace, local
+    except ValueError:
+        if "#" in uri:
+            namespace, local = uri.rsplit("#", 1)
+            return namespace + "#", local or None
+        if "/" in uri:
+            namespace, local = uri.rsplit("/", 1)
+            return namespace + "/", local or None
+        return None, None
+
+
+TYPE_LABEL_MAP: Dict[URIRef, str] = {
+    OWL.Class: "Class",
+    RDFS.Class: "Class",
+    OWL.ObjectProperty: "ObjectProperty",
+    OWL.DatatypeProperty: "DatatypeProperty",
+    OWL.AnnotationProperty: "AnnotationProperty",
+    OWL.NamedIndividual: "Individual",
+    OWL.Ontology: "Ontology",
+    RDF.Property: "Property",
+    RDFS.Datatype: "Datatype",
+    SKOS.Concept: "Concept",
+    SKOS.ConceptScheme: "ConceptScheme",
+    SKOS.Collection: "Collection",
+}
+
+
+LITERAL_PREDICATE_MAP: Dict[URIRef, str] = {
+    RDFS.label: "names",
+    SKOS.prefLabel: "pref_labels",
+    SKOS.altLabel: "alt_labels",
+    RDFS.comment: "comments",
+    SKOS.definition: "definitions",
+    SKOS.note: "notes",
+    DCTERMS.title: "titles",
+    DCTERMS.description: "descriptions",
+    DCTERMS.identifier: "identifiers",
+}
+
+
+RELATIONSHIP_MAP: Dict[URIRef, str] = {
+    RDFS.subClassOf: "SUBCLASS_OF",
+    RDFS.subPropertyOf: "SUBPROPERTY_OF",
+    RDFS.domain: "HAS_DOMAIN",
+    RDFS.range: "HAS_RANGE",
+    RDFS.isDefinedBy: "IS_DEFINED_BY",
+    RDFS.seeAlso: "SEE_ALSO",
+    OWL.equivalentClass: "EQUIVALENT_TO",
+    OWL.equivalentProperty: "EQUIVALENT_PROPERTY",
+    OWL.disjointWith: "DISJOINT_WITH",
+    OWL.sameAs: "SAME_AS",
+    OWL.inverseOf: "INVERSE_OF",
+    OWL.imports: "IMPORTS",
+    SKOS.broader: "BROADER_THAN",
+    SKOS.narrower: "NARROWER_THAN",
+    SKOS.related: "SKOS_RELATED",
+    SKOS.inScheme: "IN_SCHEME",
+}
+
+
+RELATIONSHIP_FALLBACK_TYPE = "RELATED_TO"
+
+
+@dataclass
+class ResourceRecord:
+    """Represents a node to be created in Neo4j."""
+
+    uri: str
+    labels: Set[str] = field(default_factory=lambda: {"Resource"})
+    names: Set[str] = field(default_factory=set)
+    pref_labels: Set[str] = field(default_factory=set)
+    alt_labels: Set[str] = field(default_factory=set)
+    comments: Set[str] = field(default_factory=set)
+    definitions: Set[str] = field(default_factory=set)
+    notes: Set[str] = field(default_factory=set)
+    descriptions: Set[str] = field(default_factory=set)
+    titles: Set[str] = field(default_factory=set)
+    identifiers: Set[str] = field(default_factory=set)
+    extra_annotations: Set[str] = field(default_factory=set)
+    additional_types: Set[str] = field(default_factory=set)
+    source_files: Set[str] = field(default_factory=set)
+    namespace: Optional[str] = None
+    local_name: Optional[str] = None
+    deprecated: Optional[bool] = None
+
+    def add_label(self, label: Optional[str]) -> None:
+        if label:
+            self.labels.add(label)
+
+    def add_literal(self, predicate: URIRef, value: Literal) -> None:
+        if predicate == OWL.deprecated:
+            try:
+                self.deprecated = bool(value.toPython())
+            except Exception:  # pragma: no cover - rdflib handles datatypes
+                self.deprecated = str(value).lower() == "true"
+            return
+
+        key = LITERAL_PREDICATE_MAP.get(predicate)
+        formatted = _format_literal(value)
+        if key:
+            getattr(self, key).add(formatted)
+        else:
+            self.extra_annotations.add(f"{predicate}={formatted}")
+
+    def add_type(self, uri: URIRef) -> None:
+        label = TYPE_LABEL_MAP.get(uri)
+        if label:
+            self.labels.add(label)
+        else:
+            self.additional_types.add(str(uri))
+
+    def to_serializable_dict(self) -> Dict[str, object]:
+        return {
+            "uri": self.uri,
+            "namespace": self.namespace,
+            "local_name": self.local_name,
+            "names": sorted(self.names),
+            "pref_labels": sorted(self.pref_labels),
+            "alt_labels": sorted(self.alt_labels),
+            "comments": sorted(self.comments),
+            "definitions": sorted(self.definitions),
+            "notes": sorted(self.notes),
+            "descriptions": sorted(self.descriptions),
+            "titles": sorted(self.titles),
+            "identifiers": sorted(self.identifiers),
+            "extra_annotations": sorted(self.extra_annotations),
+            "additional_types": sorted(self.additional_types),
+            "source_files": sorted(self.source_files),
+            "deprecated": self.deprecated,
+            "types": sorted(label for label in self.labels if label != "Resource"),
+            "is_class": "Class" in self.labels,
+            "is_object_property": "ObjectProperty" in self.labels,
+            "is_datatype_property": "DatatypeProperty" in self.labels,
+            "is_annotation_property": "AnnotationProperty" in self.labels,
+            "is_individual": "Individual" in self.labels,
+            "is_ontology": "Ontology" in self.labels,
+            "is_concept": "Concept" in self.labels,
+        }
+
+
+@dataclass
+class RelationshipRecord:
+    """Represents a relationship to be created in Neo4j."""
+
+    rel_type: str
+    start_uri: str
+    end_uri: str
+    predicate: str
+    source_files: Set[str] = field(default_factory=set)
+
+    def key(self) -> Tuple[str, str, str, str]:
+        return self.rel_type, self.start_uri, self.end_uri, self.predicate
+
+    def to_serializable_dict(self) -> Dict[str, object]:
+        return {
+            "type": self.rel_type,
+            "start_uri": self.start_uri,
+            "end_uri": self.end_uri,
+            "predicate": self.predicate,
+            "source_files": sorted(self.source_files),
+        }
+
+
+@dataclass
+class GraphData:
+    """Container for node/relationship records."""
+
+    nodes: List[ResourceRecord]
+    relationships: List[RelationshipRecord]
+
+    def node_dicts(self) -> List[Dict[str, object]]:
+        return [node.to_serializable_dict() for node in self.nodes]
+
+    def relationship_dicts(self) -> List[Dict[str, object]]:
+        return [rel.to_serializable_dict() for rel in self.relationships]
+
+
+class GraphBuilder:
+    """Accumulates ontology content into Neo4j-friendly structures."""
+
+    def __init__(
+        self,
+        *,
+        file_extensions: Sequence[str] = (".ttl", ".rdf", ".owl"),
+    ) -> None:
+        self._file_extensions = tuple(file_extensions)
+        self._nodes: Dict[str, ResourceRecord] = {}
+        self._relationships: Dict[Tuple[str, str, str, str], RelationshipRecord] = {}
+        self.triple_count = 0
+        self.file_count = 0
+
+    def build(self, path: Path, limit: Optional[int] = None) -> GraphData:
+        """Parse ontology files within ``path`` and return :class:`GraphData`."""
+        self.ingest_directory(path, limit=limit)
+        return GraphData(list(self._nodes.values()), list(self._relationships.values()))
+
+    def ingest_directory(self, path: Path, limit: Optional[int] = None) -> None:
+        files = sorted(
+            p
+            for p in path.rglob("*")
+            if p.is_file() and p.suffix.lower() in self._file_extensions
+        )
+        if limit is not None:
+            files = files[:limit]
+        for file_path in files:
+            self.ingest_file(file_path)
+
+    def ingest_file(self, file_path: Path) -> None:
+        fmt = guess_format(file_path.suffix)
+        graph = rdflib.Graph()
+        try:
+            graph.parse(file_path, format=fmt)
+        except Exception as exc:  # pragma: no cover - parse errors are rare but should be logged
+            LOGGER.error("Failed to parse %s: %s", file_path, exc)
+            return
+
+        LOGGER.debug("Parsed %s with %d triples", file_path, len(graph))
+        self.file_count += 1
+        self.triple_count += len(graph)
+        for subject, predicate, obj in graph:
+            if isinstance(subject, URIRef):
+                subject_record = self._get_or_create_resource(str(subject))
+                subject_record.source_files.add(str(file_path))
+                if predicate == RDF.type and isinstance(obj, URIRef):
+                    subject_record.add_type(obj)
+                    continue
+                if isinstance(obj, Literal):
+                    subject_record.add_literal(predicate, obj)
+                    continue
+            else:
+                subject_record = None
+
+            if isinstance(obj, URIRef):
+                object_record = self._get_or_create_resource(str(obj))
+                object_record.source_files.add(str(file_path))
+                if isinstance(subject, URIRef):
+                    self._add_relationship(predicate, subject_record, object_record, file_path)
+            elif isinstance(obj, Literal) and predicate == RDF.type and subject_record is not None:
+                subject_record.extra_annotations.add(f"{predicate}={_format_literal(obj)}")
+            # Blank nodes and other value types are ignored for now.
+
+    def _add_relationship(
+        self,
+        predicate: URIRef,
+        subject_record: Optional[ResourceRecord],
+        object_record: ResourceRecord,
+        file_path: Path,
+    ) -> None:
+        if subject_record is None:
+            return
+        rel_type = RELATIONSHIP_MAP.get(predicate, RELATIONSHIP_FALLBACK_TYPE)
+        record = RelationshipRecord(
+            rel_type=rel_type,
+            start_uri=subject_record.uri,
+            end_uri=object_record.uri,
+            predicate=str(predicate),
+        )
+        key = record.key()
+        existing = self._relationships.get(key)
+        if existing:
+            existing.source_files.add(str(file_path))
+        else:
+            record.source_files.add(str(file_path))
+            self._relationships[key] = record
+
+    def _get_or_create_resource(self, uri: str) -> ResourceRecord:
+        record = self._nodes.get(uri)
+        if record is None:
+            namespace, local_name = _split_namespace(uri)
+            record = ResourceRecord(uri=uri, namespace=namespace, local_name=local_name)
+            self._nodes[uri] = record
+        return record
+
+    def export_csv(self, output_dir: Path) -> Tuple[Path, Path]:
+        """Export node and relationship data to CSV files compatible with Neo4j bulk import."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+        graph_data = GraphData(list(self._nodes.values()), list(self._relationships.values()))
+        nodes_path = output_dir / "nodes.csv"
+        rels_path = output_dir / "relationships.csv"
+
+        node_fieldnames = [
+            "uri",
+            "namespace",
+            "local_name",
+            "types",
+            "names",
+            "pref_labels",
+            "alt_labels",
+            "comments",
+            "definitions",
+            "notes",
+            "descriptions",
+            "titles",
+            "identifiers",
+            "extra_annotations",
+            "additional_types",
+            "source_files",
+            "deprecated",
+        ]
+        rel_fieldnames = [
+            "type",
+            "start_uri",
+            "end_uri",
+            "predicate",
+            "source_files",
+        ]
+
+        def _stringify(value: object) -> str:
+            if isinstance(value, (list, tuple, set)):
+                return json.dumps(list(value), ensure_ascii=False)
+            if value is None:
+                return ""
+            if isinstance(value, bool):
+                return "true" if value else "false"
+            return str(value)
+
+        with nodes_path.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=node_fieldnames)
+            writer.writeheader()
+            for node in graph_data.node_dicts():
+                row = {key: _stringify(node.get(key)) for key in node_fieldnames}
+                writer.writerow(row)
+
+        with rels_path.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=rel_fieldnames)
+            writer.writeheader()
+            for rel in graph_data.relationship_dicts():
+                row = {key: _stringify(rel.get(key)) for key in rel_fieldnames}
+                writer.writerow(row)
+
+        return nodes_path, rels_path
+
+
+def build_graph(
+    path: Path,
+    *,
+    file_extensions: Sequence[str] = (".ttl", ".rdf", ".owl"),
+    limit: Optional[int] = None,
+) -> GraphData:
+    """Convenience helper to build :class:`GraphData` from ``path``."""
+    builder = GraphBuilder(file_extensions=file_extensions)
+    return builder.build(path, limit=limit)

--- a/fibo_neo4j/cli.py
+++ b/fibo_neo4j/cli.py
@@ -1,0 +1,145 @@
+"""Command line interface for building/loading FIBO into Neo4j."""
+from __future__ import annotations
+
+import argparse
+import logging
+from getpass import getpass
+from pathlib import Path
+from typing import Optional
+
+from .builder import GraphBuilder
+from .neo4j_loader import Neo4jLoader
+
+
+def _configure_logging(level: str) -> None:
+    numeric = getattr(logging, level.upper(), None)
+    if not isinstance(numeric, int):
+        raise ValueError(f"Invalid log level: {level}")
+    logging.basicConfig(level=numeric, format="%(levelname)s %(name)s - %(message)s")
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Parse FIBO ontology files and load them into Neo4j or export CSV files."
+        )
+    )
+    parser.add_argument(
+        "fibo_path",
+        type=Path,
+        help="Path to the root of the edmcouncil/fibo repository (or extracted release).",
+    )
+    parser.add_argument(
+        "--neo4j-uri",
+        dest="neo4j_uri",
+        help="Bolt URI of the Neo4j database (e.g. bolt://localhost:7687).",
+    )
+    parser.add_argument(
+        "--neo4j-user",
+        dest="neo4j_user",
+        default="neo4j",
+        help="Neo4j user name (default: neo4j).",
+    )
+    parser.add_argument(
+        "--neo4j-password",
+        dest="neo4j_password",
+        help="Neo4j password. If omitted and --neo4j-uri is provided, a prompt is shown.",
+    )
+    parser.add_argument(
+        "--neo4j-database",
+        dest="neo4j_database",
+        help="Target Neo4j database name (optional, defaults to the server's default database).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Batch size for Neo4j writes (default: 500).",
+    )
+    parser.add_argument(
+        "--limit-files",
+        type=int,
+        help="Parse only the first N ontology files (useful for testing).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory where CSV exports will be written (optional).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse the ontologies but do not write to Neo4j (still writes CSV if requested).",
+    )
+    parser.add_argument(
+        "--no-constraints",
+        dest="create_constraints",
+        action="store_false",
+        help="Do not attempt to create Neo4j uniqueness constraints.",
+    )
+    parser.set_defaults(create_constraints=True)
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ...).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = _parse_args(argv)
+    _configure_logging(args.log_level)
+
+    if not args.fibo_path.exists():
+        raise FileNotFoundError(f"FIBO path not found: {args.fibo_path}")
+
+    builder = GraphBuilder()
+    graph_data = builder.build(args.fibo_path, limit=args.limit_files)
+    logging.getLogger(__name__).info(
+        "Parsed %s ontology files containing %d triples.",
+        builder.file_count,
+        builder.triple_count,
+    )
+    logging.getLogger(__name__).info(
+        "Graph contains %d nodes and %d relationships.",
+        len(graph_data.nodes),
+        len(graph_data.relationships),
+    )
+
+    if args.output_dir is not None:
+        nodes_path, rels_path = builder.export_csv(args.output_dir)
+        logging.getLogger(__name__).info(
+            "Wrote CSV exports: nodes=%s, relationships=%s", nodes_path, rels_path
+        )
+
+    if args.neo4j_uri:
+        if args.dry_run:
+            logging.getLogger(__name__).info(
+                "Dry run requested; skipping Neo4j writes while keeping connection parameters."
+            )
+            return
+        password = args.neo4j_password
+        if password is None:
+            prompt = f"Neo4j password for user {args.neo4j_user}: "
+            password = getpass(prompt)
+        loader = Neo4jLoader(
+            args.neo4j_uri,
+            user=args.neo4j_user,
+            password=password,
+            database=args.neo4j_database,
+            batch_size=args.batch_size,
+        )
+        try:
+            loader.load(
+                graph_data,
+                create_constraints=args.create_constraints,
+                dry_run=False,
+            )
+        finally:
+            loader.close()
+    else:
+        logging.getLogger(__name__).info("Neo4j loading skipped (no URI provided).")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/fibo_neo4j/neo4j_loader.py
+++ b/fibo_neo4j/neo4j_loader.py
@@ -1,0 +1,123 @@
+"""Utilities for pushing ontology content into Neo4j."""
+from __future__ import annotations
+
+import logging
+from itertools import islice
+from typing import Iterable, Iterator, List, Optional, Sequence
+
+from neo4j import GraphDatabase, Session
+
+from .builder import GraphData
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _chunked(iterable: Sequence[dict] | Iterable[dict], size: int) -> Iterator[List[dict]]:
+    iterator = iter(iterable)
+    while True:
+        chunk = list(islice(iterator, size))
+        if not chunk:
+            break
+        yield chunk
+
+
+class Neo4jLoader:
+    """Pushes :class:`GraphData` content into a Neo4j database."""
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        user: str,
+        password: str,
+        database: Optional[str] = None,
+        batch_size: int = 500,
+    ) -> None:
+        self._driver = GraphDatabase.driver(uri, auth=(user, password))
+        self._database = database
+        self._batch_size = batch_size
+
+    def close(self) -> None:
+        self._driver.close()
+
+    def __enter__(self) -> "Neo4jLoader":  # pragma: no cover - trivial context mgmt
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial context mgmt
+        self.close()
+
+    def load(
+        self,
+        graph_data: GraphData,
+        *,
+        create_constraints: bool = True,
+        dry_run: bool = False,
+    ) -> None:
+        node_rows = graph_data.node_dicts()
+        rel_rows = graph_data.relationship_dicts()
+        LOGGER.info(
+            "Graph contains %d nodes, %d relationships", len(node_rows), len(rel_rows)
+        )
+        if dry_run:
+            return
+
+        with self._driver.session(database=self._database) as session:
+            if create_constraints:
+                self._ensure_constraints(session)
+            self._load_nodes(session, node_rows)
+            self._load_relationships(session, rel_rows)
+
+    def _ensure_constraints(self, session: Session) -> None:
+        session.run(
+            "CREATE CONSTRAINT fibo_resource_uri IF NOT EXISTS "
+            "FOR (n:Resource) REQUIRE n.uri IS UNIQUE"
+        )
+
+    def _load_nodes(self, session: Session, nodes: List[dict]) -> None:
+        query = (
+            "UNWIND $rows AS row\n"
+            "MERGE (n:Resource {uri: row.uri})\n"
+            "SET n.namespace = row.namespace,\n"
+            "    n.local_name = row.local_name,\n"
+            "    n.names = row.names,\n"
+            "    n.pref_labels = row.pref_labels,\n"
+            "    n.alt_labels = row.alt_labels,\n"
+            "    n.comments = row.comments,\n"
+            "    n.definitions = row.definitions,\n"
+            "    n.notes = row.notes,\n"
+            "    n.descriptions = row.descriptions,\n"
+            "    n.titles = row.titles,\n"
+            "    n.identifiers = row.identifiers,\n"
+            "    n.extra_annotations = row.extra_annotations,\n"
+            "    n.additional_types = row.additional_types,\n"
+            "    n.source_files = row.source_files,\n"
+            "    n.types = row.types,\n"
+            "    n.deprecated = row.deprecated\n"
+            "FOREACH (_ IN CASE WHEN row.is_class THEN [1] ELSE [] END | SET n:Class)\n"
+            "FOREACH (_ IN CASE WHEN row.is_object_property THEN [1] ELSE [] END | SET n:ObjectProperty)\n"
+            "FOREACH (_ IN CASE WHEN row.is_datatype_property THEN [1] ELSE [] END | SET n:DatatypeProperty)\n"
+            "FOREACH (_ IN CASE WHEN row.is_annotation_property THEN [1] ELSE [] END | SET n:AnnotationProperty)\n"
+            "FOREACH (_ IN CASE WHEN row.is_individual THEN [1] ELSE [] END | SET n:Individual)\n"
+            "FOREACH (_ IN CASE WHEN row.is_ontology THEN [1] ELSE [] END | SET n:Ontology)\n"
+            "FOREACH (_ IN CASE WHEN row.is_concept THEN [1] ELSE [] END | SET n:Concept)"
+        )
+        for chunk in _chunked(nodes, self._batch_size):
+            session.run(query, rows=chunk)
+
+    def _load_relationships(self, session: Session, relationships: List[dict]) -> None:
+        if not relationships:
+            return
+        rels_by_type: dict[str, List[dict]] = {}
+        for rel in relationships:
+            rels_by_type.setdefault(rel["type"], []).append(rel)
+
+        for rel_type, rows in rels_by_type.items():
+            query = (
+                "UNWIND $rows AS row\n"
+                "MATCH (start:Resource {uri: row.start_uri})\n"
+                "MATCH (end:Resource {uri: row.end_uri})\n"
+                f"MERGE (start)-[rel:{rel_type} {{predicate: row.predicate}}]->(end)\n"
+                "SET rel.source_files = row.source_files"
+            )
+            for chunk in _chunked(rows, self._batch_size):
+                session.run(query, rows=chunk)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+rdflib>=6.3
+neo4j>=5.11
+pytest>=7.0

--- a/tests/data/sample.ttl
+++ b/tests/data/sample.ttl
@@ -1,0 +1,29 @@
+@prefix ex: <http://example.com/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:Thing a owl:Class ;
+    rdfs:label "Thing"@en .
+
+ex:Account a owl:Class ;
+    rdfs:label "Account"@en ;
+    rdfs:comment "Represents an account." ;
+    rdfs:subClassOf ex:Thing .
+
+ex:hasAccount a owl:ObjectProperty ;
+    rdfs:label "has account" ;
+    rdfs:domain ex:Customer ;
+    rdfs:range ex:Account ;
+    rdfs:subPropertyOf ex:relatedTo .
+
+ex:relatedTo a owl:ObjectProperty .
+
+ex:Customer a owl:Class ;
+    skos:prefLabel "Customer"@en ;
+    skos:definition "An individual or organization with an account." .
+
+ex:customer123 a owl:NamedIndividual ;
+    rdf:type ex:Customer ;
+    rdfs:label "Customer 123" .

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from fibo_neo4j.builder import GraphBuilder
+
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+def test_builder_parses_sample_graph(tmp_path: Path) -> None:
+    builder = GraphBuilder()
+    graph_data = builder.build(DATA_DIR)
+
+    assert builder.file_count == 1
+    assert builder.triple_count > 0
+    assert len(graph_data.nodes) >= 5
+
+    nodes_by_uri = {node.uri: node for node in graph_data.nodes}
+    account = nodes_by_uri["http://example.com/Account"]
+    assert "Class" in account.labels
+    assert "Account (@en)" in account.names
+    assert "Represents an account." in account.comments
+
+    customer = nodes_by_uri["http://example.com/Customer"]
+    assert "Class" in customer.labels
+    assert "Customer (@en)" in customer.pref_labels
+    assert (
+        "An individual or organization with an account."
+        in customer.definitions
+    )
+
+    relationships = {(rel.rel_type, rel.start_uri, rel.end_uri) for rel in graph_data.relationships}
+    assert (
+        "SUBCLASS_OF",
+        "http://example.com/Account",
+        "http://example.com/Thing",
+    ) in relationships
+    assert (
+        "HAS_DOMAIN",
+        "http://example.com/hasAccount",
+        "http://example.com/Customer",
+    ) in relationships
+    assert (
+        "HAS_RANGE",
+        "http://example.com/hasAccount",
+        "http://example.com/Account",
+    ) in relationships
+
+
+def test_export_csv_creates_files(tmp_path: Path) -> None:
+    builder = GraphBuilder()
+    builder.build(DATA_DIR)
+    nodes_path, rels_path = builder.export_csv(tmp_path)
+    assert nodes_path.exists()
+    assert rels_path.exists()
+    assert nodes_path.stat().st_size > 0
+    assert rels_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add a `fibo_neo4j` package that parses FIBO ontology files, extracts nodes/relationships, and optionally loads them into Neo4j
- provide a CLI for driving the conversion, CSV export helpers, and dependency list
- cover the graph builder with unit tests and sample ontology data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbea853a10832d985626a3d561709f